### PR TITLE
Never render the View my Records button

### DIFF
--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -93,17 +93,9 @@ class ProfilePage extends React.Component {
     this.props.updateDraft(name, value);
   }
 
-  // Inserted into the DOM in two places (for responsive layout)
+  // Never render the View my records button.
   renderViewMyRecordsButton() {
-    if (!this.isAuthenticatedUserProfile()) {
       return null;
-    }
-
-    return (
-      <Hyperlink className="btn btn-primary" destination={this.state.viewMyRecordsUrl} target="_blank">
-        {this.props.intl.formatMessage(messages['profile.viewMyRecords'])}
-      </Hyperlink>
-    );
   }
 
   // Inserted into the DOM in two places (for responsive layout)


### PR DESCRIPTION


This prevents us from rendering the View my records button that depends on a service that currently is not installed in this installation.

Without this change:

![image](https://user-images.githubusercontent.com/22335041/105099511-2b155a00-5a82-11eb-8480-530abf5a0fe7.png)


With this change (in the devstack)

![image](https://user-images.githubusercontent.com/22335041/105099572-46806500-5a82-11eb-8dbe-f687e557c381.png)

Reviewers:

- [x] @amalbas
- [ ] @mariajgrimaldi
- [ ] @MoisesGSalas
